### PR TITLE
Adjusting the Healthcheck timing parameters

### DIFF
--- a/.aws/ecs_task_definition.json
+++ b/.aws/ecs_task_definition.json
@@ -23,8 +23,8 @@
                 "command": 
                     [ "CMD-SHELL", "curl -f http://localhost:8034/actuator/health || exit 1" ]
                 ,
-                "interval": 30,
-                "timeout": 8000,
+                "interval": 300,
+                "timeout": 30,
                 "retries": 4,
                 "startPeriod": 4000
             }


### PR DESCRIPTION
The rule is the that the timeout needs to be less than the default 60 seconds.