### PR TITLE
Adjusting the start time for health checks.

### DIFF
--- a/.aws/ecs_task_definition.json
+++ b/.aws/ecs_task_definition.json
@@ -26,7 +26,7 @@
                 "interval": 300,
                 "timeout": 30,
                 "retries": 4,
-                "startPeriod": 4000
+                "startPeriod": 25
             }
         }
     ]


### PR DESCRIPTION
The start period now set to 20 seconds after startup time of the application to check the health. App should start much sooner, but just being safe.